### PR TITLE
Convert serial connection to use KegboardPacket

### DIFF
--- a/KegboardPacket.cpp
+++ b/KegboardPacket.cpp
@@ -1,0 +1,158 @@
+/**
+ * kegboard.pde - Kegboard v3 Arduino project
+ * Copyright 2003-2011 Mike Wakerly <opensource@hoho.com>
+ *
+ * This file is part of the Kegbot package of the Kegbot project.
+ * For more information on Kegbot, see http://kegbot.org/
+ *
+ * Kegbot is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Kegbot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kegbot.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Arduino.h"
+#include "kegboard.h"
+#include "KegboardPacket.h"
+
+#include <string.h>
+
+// Non-assembly implementation of crc16 function
+static uint16_t _crc_ccitt_update (uint16_t crc, uint8_t data) {
+  data ^= (crc & 0xff);
+  data ^= data << 4;
+
+  return ((((uint16_t)data << 8) | ((crc >> 8) & 0xff)) ^ (uint8_t)(data >> 4)
+    ^ ((uint16_t)data << 3));
+}
+
+static uint16_t crc_ccitt_update_int(uint16_t crc, int value) {
+  crc = _crc_ccitt_update(crc, value & 0xff);
+  return _crc_ccitt_update(crc, (value >> 8) & 0xff);
+}
+
+static void serial_print_int(int value) {
+  Serial.write(value & 0xff);
+  Serial.write((value >> 8) & 0xff);
+}
+
+KegboardPacket::KegboardPacket()
+{
+  Reset();
+}
+
+bool KegboardPacket::IsReset() {
+  return (m_type == 0) && (m_len == 0);
+}
+
+void KegboardPacket::Reset()
+{
+  m_len = 0;
+  m_type = 0;
+}
+
+void KegboardPacket::AddTag(uint8_t tag, uint8_t buflen, const char *buf)
+{
+  m_payload[m_len++] = tag;
+  m_payload[m_len++] = buflen;
+  AppendBytes(buf, buflen);
+}
+
+int KegboardPacket::FindTagLength(uint8_t tagnum) {
+  uint8_t* buf = FindTag(tagnum);
+  if (buf == NULL) {
+    return -1;
+  }
+  return buf[1] & 0xff;
+}
+
+uint8_t* KegboardPacket::FindTag(uint8_t tagnum) {
+  uint8_t pos=0;
+  while (pos < m_len && pos < KBSP_PAYLOAD_MAXLEN) {
+    uint8_t tag = m_payload[pos];
+    if (tag == tagnum) {
+      return m_payload+pos;
+    }
+    pos += 2 + m_payload[pos+1];
+  }
+  return NULL;
+}
+
+bool KegboardPacket::ReadTag(uint8_t tagnum, uint8_t *value) {
+  uint8_t *offptr = FindTag(tagnum);
+  if (offptr == NULL) {
+    return false;
+  }
+  *value = *(offptr+2);
+  return true;
+}
+
+int KegboardPacket::CopyTagData(uint8_t tagnum, void* dest) {
+  uint8_t *offptr = FindTag(tagnum);
+  if (offptr == NULL) {
+    return -1;
+  }
+  uint8_t slen = *(offptr+1);
+  memcpy(dest, (offptr+2), slen);
+  return slen;
+}
+
+void KegboardPacket::AppendBytes(const char *buf, int buflen)
+{
+  int i=0;
+  while (i < buflen && m_len < KBSP_PAYLOAD_MAXLEN) {
+    m_payload[m_len++] = (uint8_t) (*(buf+i));
+    i++;
+  }
+}
+
+uint16_t KegboardPacket::GenCrc()
+{
+  uint16_t crc = KBSP_PREFIX_CRC;
+
+  crc = crc_ccitt_update_int(crc, m_type);
+  crc = crc_ccitt_update_int(crc, m_len);
+
+  for (int i=0; i<m_len; i++) {
+    crc = _crc_ccitt_update(crc, m_payload[i]);
+  }
+
+  return crc;
+}
+
+void KegboardPacket::Print()
+{
+  int i;
+  uint16_t crc = KBSP_PREFIX_CRC;
+
+  // header
+  // header: prefix
+  Serial.print(KBSP_PREFIX);
+
+  // header: message_id
+  serial_print_int(m_type);
+  crc = crc_ccitt_update_int(crc, m_type);
+
+  // header: payload_len
+  serial_print_int(m_len);
+  crc = crc_ccitt_update_int(crc, m_len);
+
+  // payload
+  for (i=0; i<m_len; i++) {
+    Serial.write(m_payload[i]);
+    crc = _crc_ccitt_update(crc, m_payload[i]);
+  }
+
+  // trailer
+  serial_print_int(crc);
+  Serial.write('\r');
+  Serial.write('\n');
+}

--- a/KegboardPacket.h
+++ b/KegboardPacket.h
@@ -1,0 +1,26 @@
+#include <inttypes.h>
+
+class KegboardPacket {
+  public:
+   KegboardPacket();
+   void SetType(int type) {m_type = type;}
+   int GetType() {return m_type;}
+   void AddTag(uint8_t tag, uint8_t buflen, const char *buf);
+
+   bool ReadTag(uint8_t tagnum, uint8_t *value);
+   int CopyTagData(uint8_t tagnum, void *dest);
+
+   // Returns length of tag's payload, or -1 if not found.
+   int FindTagLength(uint8_t tagnum);
+   uint8_t* FindTag(uint8_t tagnum);
+
+   void AppendBytes(const char *buf, int buflen);
+   void Reset();
+   bool IsReset();
+   void Print();
+   uint16_t GenCrc();
+  private:
+   int m_type;
+   uint8_t m_len;
+   uint8_t m_payload[KBSP_PAYLOAD_MAXLEN];
+};

--- a/kegboard.h
+++ b/kegboard.h
@@ -1,0 +1,92 @@
+#define LOG(s) Serial.println(s);
+
+#define KB_BOARDNAME_MAXLEN   8
+
+#define KBM_HELLO_ID      0x01
+#define KBM_HELLO_TAG_FIRMWARE_VERSION  0x01
+#define KBM_HELLO_TAG_PROTOCOL_VERSION  0x02
+#define KBM_HELLO_TAG_SERIAL_NUMBER  0x03
+#define KBM_HELLO_TAG_UPTIME_MILLIS  0x04
+#define KBM_HELLO_TAG_UPTIME_DAYS  0x05
+
+#define KBM_THERMO_READING 0x11
+#define KBM_THERMO_READING_TAG_SENSOR_NAME  0x01
+#define KBM_THERMO_READING_TAG_SENSOR_READING  0x02
+
+#define KBM_METER_STATUS 0x10
+#define KBM_METER_STATUS_TAG_METER_NAME  0x01
+#define KBM_METER_STATUS_TAG_METER_READING  0x02
+
+#define KBM_OUTPUT_STATUS 0x12
+#define KBM_OUTPUT_STATUS_TAG_OUTPUT_NAME  0x01
+#define KBM_OUTPUT_STATUS_TAG_OUTPUT_READING  0x02
+
+#define KBM_ONEWIRE_PRESENCE 0x13
+#define KBM_ONEWIRE_PRESENCE_TAG_DEVICE_ID  0x01
+#define KBM_ONEWIRE_PRESENCE_TAG_STATUS 0x02
+
+#define KBM_AUTH_TOKEN 0x14
+#define KBM_AUTH_TOKEN_TAG_DEVICE 0x01
+#define KBM_AUTH_TOKEN_TAG_TOKEN 0x02
+#define KBM_AUTH_TOKEN_TAG_STATUS 0x03
+
+#define KBM_PING 0x81
+
+#define KBM_SET_OUTPUT 0x84
+#define KBM_SET_OUTPUT_TAG_OUTPUT_ID 0x01
+#define KBM_SET_OUTPUT_TAG_OUTPUT_MODE 0x02
+
+#define OUTPUT_DISABLED 0
+#define OUTPUT_ENABLED 1
+
+#define KBM_SET_SERIAL_NUMBER 0x85
+#define KBM_SET_SERIAL_NUMBER_TAG_SERIAL 0x01
+
+#define KBSP_PREFIX "KBSP v1:"
+#define KBSP_PREFIX_CRC 0xe3af
+#define KBSP_TRAILER "\r\n"
+
+#define KBSP_HEADER_LEN 12
+#define KBSP_HEADER_PREFIX_LEN 8
+#define KBSP_HEADER_ID_LEN 2
+#define KBSP_HEADER_PAYLOADLEN_LEN 2
+
+#define KBSP_FOOTER_LEN 4
+#define KBSP_FOOTER_CRC_LEN 2
+#define KBSP_FOOTER_TRAILER_LEN 2
+
+#define KBSP_PAYLOAD_MAXLEN 112
+
+// Milliseconds/day
+#define MS_PER_DAY  86400000UL
+// Interval between test pulse trains
+#define KB_SELFTEST_INTERVAL_MS 500
+
+// Number of pulses per test pulse train
+#define KB_SELFTEST_PULSES 10
+
+// Minimum time, in MS, between meter update packets. Setting this to zero will
+// cause the kegboard to send a meter update message for nearly every tick; this
+// is not recommended.
+#define KB_METER_UPDATE_INTERVAL_MS 100
+
+// Heartbeat interval.  A "hello" packet will be emitted to the host this often.
+#define KB_HEARTBEAT_INTERVAL_MS (10 * 1000)
+
+// Number of relay outputs
+#define KB_NUM_RELAY_OUTPUTS 6
+
+// Maximum time a relay will remain enabled after a "set_output" command.  The
+// timer is reset whenenver a new "set_output" command is received.
+#define KB_RELAY_WATCHDOG_MS 10000
+
+// RFID defines
+#define STX 0x02
+#define ETX 0x03
+#define RFID_DATA_CHARS 10
+#define RFID_CHECKSUM_CHARS 2
+#define RFID_PARALLAX_PAYLOAD_CHARS 4
+#define RFID_PARALLAX_LEGACY_PAYLOAD_CHARS 10
+#define RFID_PAYLOAD_CHARS 12
+#define CR '\r'
+#define LF '\n'


### PR DESCRIPTION
I was able to copy most of the existing functions and code from the arduino kegboard project, but had to make a couple modifications. I could not find an AVR equivalent in the Particle world, but found a way to get the CRC to work. 

Known issues:
- Firmware version as parsed by kegtab is `0`. I'm not sure if the version is not being set on this side, or parsed on the kegtab side.

Needs a small update to kegtab to work with a Particle Photon: https://github.com/patfreeman/kegbot-android/commit/88e87694f3da3bd40d15691b6d3ce711d77538ff